### PR TITLE
Fix config save filename generation for non-base class types

### DIFF
--- a/js/data.js
+++ b/js/data.js
@@ -454,7 +454,12 @@ export class Data {
     const blob = new Blob([jsonData], { type: 'application/json' });
     const url = URL.createObjectURL(blob);
     
-    const className = data.classType === 'dictionary' ? `${data.dictionary.dictBase}Dictionary` : data.base.className;
+    let className = '';
+    if (data.classType === 'dictionary') {
+      className = `${data.dictionary?.dictBase || ''}Dictionary`;
+    } else if (data.classType === 'base') {
+      className = data.base?.className || '';
+    }
     const fileName = `${className || 'class_data'}_config.json`;
     
     const a = document.createElement('a');


### PR DESCRIPTION
### Motivation
- Prevent a runtime error when saving config if `classType` is not `base` (for example `array` or `catalog`) because the previous code unconditionally accessed `data.base.className`.

### Description
- Update `Data.saveToFile()` to compute the download filename safely with class-type-aware logic and optional chaining so that `dictionary` uses `${dictBase}Dictionary`, `base` uses `className`, and all other/unsupported types fall back to `class_data`.

### Testing
- Ran `node --check js/data.js` and `node --check js/main.js`, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a20c226134832f9fdda96965774187)